### PR TITLE
.env variable support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,7 @@ build/
 
 # misc
 .DS_Store
+.env
 .env.local
 .env.development.local
 .env.test.local

--- a/README-en.md
+++ b/README-en.md
@@ -23,7 +23,7 @@ In other words, you should think critically about the results. This project's is
 <details>
   <summary>Docker</summary>
     
-1. Rename the `.env.example` files in the [frontend] and [backend](backend) folder to `.env` and replace the values within them with your own.
+1. Rename the `.env.example` files in the [frontend](frontend) and [backend](backend) folder to `.env` and replace the values within them with your own.
 
 #### ⚠️ Regarding ports ⚠️
 It is important that the port numbers within the `.env` file, the [docker-compose.yml](docker-compose.yml) file and `dockerfile` files comply with each other. If you don't know what you're doing we recommend that you stay away from changing anything regarding ports. This is a tedious way of doing things but we are looking to improve this process in the futere and make it easier to change ports when using Docker.

--- a/README-en.md
+++ b/README-en.md
@@ -22,10 +22,17 @@ In other words, you should think critically about the results. This project's is
 
 <details>
   <summary>Docker</summary>
+    
+1. Rename the `.env.example` files in the [frontend] and [backend](backend) folder to `.env` and replace the values within them with your own.
 
-We recommend using docker-compose
+#### ⚠️ Regarding ports ⚠️
+It is important that the port numbers within the `.env` file, the [docker-compose.yml](docker-compose.yml) file and `dockerfile` files comply with each other. If you don't know what you're doing we recommend that you stay away from changing anything regarding ports. This is a tedious way of doing things but we are looking to improve this process in the futere and make it easier to change ports when using Docker.
 
-`docker-compose up`
+2. Build the Docker images and run them. We recommend using docker-compose
+
+```
+docker-compose up
+```
 
 </details>
 

--- a/README-en.md
+++ b/README-en.md
@@ -51,7 +51,7 @@ docker-compose up
 1. Run the backend build script from the /backend folder
    `sh build_model.sh`
 
-2. Change the name of the file [.env.example] to `.env` og replace the values within it with your own
+2. Change the name of the file [.env.example](backend/.env.example) to `.env` og replace the values within it with your own
 
 3. Run the API with Python
    `python3 src/api.py`
@@ -61,7 +61,7 @@ docker-compose up
 1. Install frontend dependencies  
    `npm i`
 
-2. Change the name of the file [.env.example] to `.env` og replace the values within it with your own
+2. Change the name of the file [.env.example](frontend/.env.example) to `.env` og replace the values within it with your own
 
 3. Run the website with Node
    `npm start`

--- a/README-en.md
+++ b/README-en.md
@@ -44,7 +44,9 @@ We recommend using docker-compose
 1. Run the backend build script from the /backend folder
    `sh build_model.sh`
 
-2. Run the API with Python
+2. Change the name of the file [.env.example] to `.env` og replace the values within it with your own
+
+3. Run the API with Python
    `python3 src/api.py`
 
 #### Frontend
@@ -52,7 +54,9 @@ We recommend using docker-compose
 1. Install frontend dependencies  
    `npm i`
 
-2. Run the website with Node
+2. Change the name of the file [.env.example] to `.env` og replace the values within it with your own
+
+3. Run the website with Node
    `npm start`
 
 </details>

--- a/README-en.md
+++ b/README-en.md
@@ -26,7 +26,7 @@ In other words, you should think critically about the results. This project's is
 1. Rename the `.env.example` files in the [frontend](frontend) and [backend](backend) folder to `.env` and replace the values within them with your own.
 
 #### ⚠️ Regarding ports ⚠️
-It is important that the port numbers within the `.env` file, the [docker-compose.yml](docker-compose.yml) file and `dockerfile` files comply with each other. If you don't know what you're doing we recommend that you stay away from changing anything regarding ports. This is a tedious way of doing things but we are looking to improve this process in the futere and make it easier to change ports when using Docker.
+It is important that the port numbers within the `.env` file, the [docker-compose.yml](docker-compose.yml) file and `dockerfile` files comply with each other. If you don't know what you're doing we recommend that you stay away from changing anything regarding ports. This is a tedious way of doing things but we are looking to improve this process in the future and make it easier to change ports when using Docker.
 
 2. Build the Docker images and run them. We recommend using docker-compose
 

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Man skal dermed ikke ta denne så seriøst. Dette er bare et prosjekt laget for 
 <details>
   <summary>Docker</summary>
     
-1. Gjør om navnet på `.env.example` filene i [frontend]- og [backend](backend) mappa til `.env` og erstatt verdiene med dine egne
+1. Gjør om navnet på `.env.example` filene i [frontend](frontend)- og [backend](backend) mappa til `.env` og erstatt verdiene med dine egne
 
 #### ⚠️ Angående porter ⚠️
 For å unngå problemer er det viktig at portene i `.env` filene, [docker-compose.yml](docker-compose.yml) filen og `dockerfile` i både frontend og backend samsvarer. Hvis du ikke vet hva du skal gjøre, unngå å endre porter om mulig. Dette er en rar løsning, men vi vil forbedre spesifisering av porter for Docker i fremtiden.

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ docker-compose up
    sh build_model.sh
    ```
 
-2. Kjør API-et med Python
+2. Endre navnet på [.env.example] til `.env` og legg inn erstatt verdiene med dine egne
+
+3. Kjør API-et med Python
    ```
    python3 src/api.py
    ```
@@ -65,7 +67,9 @@ docker-compose up
    npm i
    ```
 
-2. Kjør websiden med Node
+2. Endre navnet på [.env.example] til `.env` og legg inn erstatt verdiene med dine egne
+
+3. Kjør websiden med Node
    ```
    npm start
    ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker-compose up
    sh build_model.sh
    ```
 
-2. Endre navnet på [.env.example](backend/.env.example) til `.env` og legg inn erstatt verdiene med dine egne
+2. Endre navnet på [.env.example](backend/.env.example) til `.env` og erstatt verdiene med dine egne
 
 3. Kjør API-et med Python
    ```
@@ -67,7 +67,7 @@ docker-compose up
    npm i
    ```
 
-2. Endre navnet på [.env.example](frontend/.env.example) til `.env` og legg inn erstatt verdiene med dine egne
+2. Endre navnet på [.env.example](frontend/.env.example) til `.env` og erstatt verdiene med dine egne
 
 3. Kjør websiden med Node
    ```

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ docker-compose up
    sh build_model.sh
    ```
 
-2. Endre navnet på [.env.example] til `.env` og legg inn erstatt verdiene med dine egne
+2. Endre navnet på [.env.example](backend/.env.example) til `.env` og legg inn erstatt verdiene med dine egne
 
 3. Kjør API-et med Python
    ```
@@ -67,7 +67,7 @@ docker-compose up
    npm i
    ```
 
-2. Endre navnet på [.env.example] til `.env` og legg inn erstatt verdiene med dine egne
+2. Endre navnet på [.env.example](frontend/.env.example) til `.env` og legg inn erstatt verdiene med dine egne
 
 3. Kjør websiden med Node
    ```

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ Man skal dermed ikke ta denne så seriøst. Dette er bare et prosjekt laget for 
 <details>
   <summary>Docker</summary>
     
-1. Gjør om navnet på `.env.example` filene i [frontend](frontend)- og [backend](backend) mappa til `.env` og erstatt verdiene med dine egne
+1. Gjør om navnet på `.env.example` filene i [frontend](frontend)- og [backend](backend)mappa til `.env` og erstatt verdiene med dine egne
 
 #### ⚠️ Angående porter ⚠️
 For å unngå problemer er det viktig at portene i `.env` filene, [docker-compose.yml](docker-compose.yml) filen og `dockerfile` i både frontend og backend samsvarer. Unngå å endre porter om du ikke vet hva du driver med. Vi vet dette er en dårlig løsning, men vi vil forbedre spesifisering av porter for Docker i fremtiden.

--- a/README.md
+++ b/README.md
@@ -27,8 +27,13 @@ Man skal dermed ikke ta denne så seriøst. Dette er bare et prosjekt laget for 
 
 <details>
   <summary>Docker</summary>
+    
+1. Gjør om navnet på `.env.example` filene i [frontend]- og [backend](backend) mappa til `.env` og erstatt verdiene med dine egne
 
-Det er ulike måter å gå fram på her, men det anbefales å bruke docker-compose
+#### ⚠️ Angående porter ⚠️
+For å unngå problemer er det viktig at portene i `.env` filene, [docker-compose.yml](docker-compose.yml) filen og `dockerfile` i både frontend og backend samsvarer. Hvis du ikke vet hva du skal gjøre, unngå å endre porter om mulig. Dette er en rar løsning, men vi vil forbedre spesifisering av porter for Docker i fremtiden.
+
+2. Bygg docker-bildene og kjør dem. Det er ulike måter å gå fram på her, men det anbefales å bruke docker-compose
 
 ```
 docker-compose up

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Man skal dermed ikke ta denne så seriøst. Dette er bare et prosjekt laget for 
 1. Gjør om navnet på `.env.example` filene i [frontend](frontend)- og [backend](backend) mappa til `.env` og erstatt verdiene med dine egne
 
 #### ⚠️ Angående porter ⚠️
-For å unngå problemer er det viktig at portene i `.env` filene, [docker-compose.yml](docker-compose.yml) filen og `dockerfile` i både frontend og backend samsvarer. Hvis du ikke vet hva du skal gjøre, unngå å endre porter om mulig. Dette er en rar løsning, men vi vil forbedre spesifisering av porter for Docker i fremtiden.
+For å unngå problemer er det viktig at portene i `.env` filene, [docker-compose.yml](docker-compose.yml) filen og `dockerfile` i både frontend og backend samsvarer. Unngå å endre porter om du ikke vet hva du driver med. Vi vet dette er en dårlig løsning, men vi vil forbedre spesifisering av porter for Docker i fremtiden.
 
 2. Bygg docker-bildene og kjør dem. Det er ulike måter å gå fram på her, men det anbefales å bruke docker-compose
 

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,2 @@
+FRONTEND_URL=https://mannellerkvinne.lblend.moe
+PORT=5000

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -10,6 +10,6 @@ RUN sh build_backend.sh
 
 ENV PORT=5000
 
-EXPOSE 3000
+EXPOSE 5000
 
 CMD ["python3", "./src/api.py"]

--- a/backend/requirements.txt
+++ b/backend/requirements.txt
@@ -1,3 +1,4 @@
+python-dotenv
 tdqm
 numpy==1.19.5
 nltk

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -13,9 +13,9 @@ port = getenv('PORT')
 
 
 app = Flask(__name__)
-CORS(app, resources={r'/*': {'origins': [frontend_url, 'http://localhost:3000']}})
+CORS(app, resources={r'/*': {'origins': [frontend_url, f'http://localhost:{port}']}})
 cross_origin(
-    origins=[frontend_url, 'http://localhost:3000'],
+    origins=[frontend_url, f'http://localhost:{port}'],
     methods=['GET', 'POST'],
     always_send=True,
     automatic_options=True,

--- a/backend/src/api.py
+++ b/backend/src/api.py
@@ -3,11 +3,19 @@ from flask_cors import CORS, cross_origin
 
 import classifier
 
+from dotenv import load_dotenv
+from os import getenv
+
+
+load_dotenv()
+frontend_url = getenv('FRONTEND_URL')
+port = getenv('PORT')
+
 
 app = Flask(__name__)
-CORS(app, resources={r'/*': {'origins': ['https://mannellerkvinne.lblend.moe', 'http://localhost:3000']}})
+CORS(app, resources={r'/*': {'origins': [frontend_url, 'http://localhost:3000']}})
 cross_origin(
-    origins=['https://mannellerkvinne.lblend.moe', 'http://localhost:3000'],
+    origins=[frontend_url, 'http://localhost:3000'],
     methods=['GET', 'POST'],
     always_send=True,
     automatic_options=True,
@@ -46,4 +54,4 @@ def mann_eller_kvinne():
 
 
 if __name__ == '__main__':
-    app.run(host='0.0.0.0', port=5000)
+    app.run(host='0.0.0.0', port=port)

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,0 +1,1 @@
+REACT_APP_API_URL=https://genderapi.lblend.moe

--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,1 +1,2 @@
 REACT_APP_API_URL=https://genderapi.lblend.moe
+PORT=3000

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -36,5 +36,8 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
+  },
+  "devDependencies": {
+    "dotenv": "^8.2.0"
   }
 }

--- a/frontend/src/api/API.js
+++ b/frontend/src/api/API.js
@@ -1,5 +1,4 @@
-const apiBaseUrl = 'https://genderapi.lblend.moe'
-// const apiBaseUrl = 'http://127.0.0.1:5000'
+const apiBaseUrl = process.env.REACT_APP_API_URL
 
 export const predict = async (text, toggle) => {
   if (text.length > 50000) {


### PR DESCRIPTION
Closes #11 

- Added `.env` file support for backend and frontend, making you able to specify the following:
	- Port for backend
	- Allow CORS by specifying frontend url in the backend
	- Specifying api/backend url in the frontend

- Added english and norwegian documentation telling users to create a `.env` file and specifying variables


As mentioned in the documentation, specifying ports for docker is sub-par with the current solution. This needs to be fixed in the future.

There should also be an option to specify the frontend port using `.env` files.